### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cataleya-core.yml
+++ b/.github/workflows/cataleya-core.yml
@@ -1,5 +1,7 @@
 name: Nueva_Obra_Google_SPlus
 on: [push]
+permissions:
+  contents: read
 
 jobs:
   agentes_y_modelos:


### PR DESCRIPTION
Potential fix for [https://github.com/kach1091-cmd/improved-palm-tree/security/code-scanning/1](https://github.com/kach1091-cmd/improved-palm-tree/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so it applies to all jobs that do not override permissions.  
For this workflow, the minimal safe setting is:

- `contents: read`

This preserves existing functionality (`actions/checkout@v4` still works) while preventing unintended broader token access.

**File to change:** `.github/workflows/cataleya-core.yml`  
**Region:** Immediately after the `on:` declaration (before `jobs:`).  
No imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
